### PR TITLE
Limit wheel builds to newer versions of Python and skip some architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
+    env:
+      # Set up wheels matrix.  This is CPython 3.10--3.14 for all OS targets.
+      CIBW_BUILD: "cp3{10,11,12,13,14}-*"
+      # Numpy and SciPy do not supply wheels for i686 or win32 for
+      # Python 3.10+, so we skip those:
+      CIBW_SKIP: "*-musllinux* *-manylinux_i686 *-win32"
+      # Force recent version of manylinux
+      # manylinux2014 no longer supported by scipy and numpy
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Currently, wheels are generated also for versions of Python that are close-to or experienced end-to-life (https://devguide.python.org/versions/). This PR changes this via aligning the build config according to how we do it in the main `qutip` repository.