### PR TITLE
Upgrade minimum Python version for test and build workflows + actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,66 +6,80 @@ on:
       confirm_ref:
         description: "Confirm chosen branch name to deploy to PyPI (optional):"
         default: ""
+
       override_version:
         description: "Override version number (optional):"
         default: ""
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     env:
-      # Set up wheels matrix.  This is CPython 3.10--3.14 for all OS targets.
-      CIBW_BUILD: "cp3{10,11,12,13,14}-*"
-      # Numpy and SciPy do not supply wheels for i686 or win32 for
-      # Python 3.10+, so we skip those:
+      # Build wheels for supported CPython versions.
+      CIBW_BUILD: "cp3{11,12,13,14}-*"
+
+      # NumPy and SciPy do not supply wheels for these targets.
       CIBW_SKIP: "*-musllinux* *-manylinux_i686 *-win32"
-      # Force recent version of manylinux
-      # manylinux2014 no longer supported by scipy and numpy
+
+      # manylinux2014 no longer supported by scipy/numpy
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+
       - name: Install cibuildwheel
-        run: >-
-          python3 -m
-          pip install
-          cibuildwheel
-          --user
-      - name: Build a binary wheel and a source tarball
-        run: python3 -m cibuildwheel --output-dir dist
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel
+
+      - name: Build binary wheels and source tarball
+        run: |
+          python -m cibuildwheel --output-dir dist
+
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v5
         with:
           name: python-package-distributions-${{ matrix.os }}
           path: dist/
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
+
     if: ${{ github.event.inputs.confirm_ref != '' && github.event.inputs.confirm_ref != 'test' }}
+
     needs:
       - build
+
     runs-on: ubuntu-latest
+
     environment:
       name: pypi
       url: https://pypi.org/p/qutip-qoc
+
     permissions:
       id-token: write
 
     steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
+      - name: Download all distributions
+        uses: actions/download-artifact@v5
         with:
           pattern: python-package-distributions-*
           path: dist/
           merge-multiple: true
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ on:
         description: "Override version number (optional):"
         default: ""
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: Build distribution 📦

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel
+          python -m pip install "cibuildwheel>=2.20,<3"
 
       - name: Build binary wheels and source tarball
         run: |

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Pandoc
         run: |
@@ -22,11 +22,12 @@ jobs:
 
       - name: Install documentation dependencies
         run: |
-          python -mpip install -r doc/requirements.txt
+          python -m pip install --upgrade pip
+          python -m pip install -r doc/requirements.txt
 
       - name: Install qutip-qoc from GitHub
         run: |
-          python -mpip install -e .[full]
+          python -m pip install -e .[full]
           # Install in editable mode so it doesn't matter if we import from
           # inside the installation directory, otherwise we can get some errors
           # because we're importing from the wrong location.
@@ -42,7 +43,7 @@ jobs:
           #   -T : display a full traceback if a Python exception occurs
 
       - name: Upload built files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qutip_qoc_html_docs
           path: doc/_build/html/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,22 +39,6 @@ jobs:
             os: windows-latest
             qutip-version: "@master"
             python-version: "3.12"
-
-          - case-name: ubuntu-python3.13
-            os: ubuntu-latest
-            qutip-version: "@master"
-            python-version: "3.13"
-
-          - case-name: macOs-python3.13
-            os: macOS-latest
-            qutip-version: "@master"
-            python-version: "3.13"
-
-          - case-name: windows-python3.13
-            os: windows-latest
-            qutip-version: "@master"
-            python-version: "3.13"
-
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
             python-version: "3.12"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,60 +6,74 @@ jobs:
   cases:
     name: ${{ matrix.os }}, python${{ matrix.python-version }}, ${{ matrix.case-name }}
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         include:
-          - case-name: ubuntu-python3.10
-            os: ubuntu-latest
-            qutip-version: "@master"
-            python-version: "3.10"
-          - case-name: macOs-python3.10
-            os: macOS-latest
-            qutip-version: "@master"
-            python-version: "3.10"
-          - case-name: windows-python3.10
-            os: windows-latest
-            qutip-version: "@master"
-            python-version: "3.10"
           - case-name: ubuntu-python3.11
             os: ubuntu-latest
             qutip-version: "@master"
             python-version: "3.11"
+
           - case-name: macOs-python3.11
             os: macOS-latest
             qutip-version: "@master"
             python-version: "3.11"
+
           - case-name: windows-python3.11
             os: windows-latest
             qutip-version: "@master"
             python-version: "3.11"
+
           - case-name: ubuntu-python3.12
             os: ubuntu-latest
             qutip-version: "@master"
             python-version: "3.12"
+
           - case-name: macOs-python3.12
             os: macOS-latest
             qutip-version: "@master"
             python-version: "3.12"
+
           - case-name: windows-python3.12
             os: windows-latest
             qutip-version: "@master"
             python-version: "3.12"
 
+          - case-name: ubuntu-python3.13
+            os: ubuntu-latest
+            qutip-version: "@master"
+            python-version: "3.13"
+
+          - case-name: macOs-python3.13
+            os: macOS-latest
+            qutip-version: "@master"
+            python-version: "3.13"
+
+          - case-name: windows-python3.13
+            os: windows-latest
+            qutip-version: "@master"
+            python-version: "3.13"
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip
+
       - name: Install QuTiP from GitHub
-        if: ${{ matrix.qutip-version == '@master'}}
+        if: ${{ matrix.qutip-version == '@master' }}
         run: |
           python -m pip install 'git+https://github.com/qutip/qutip.git${{ matrix.qutip-version }}'
 
       - name: Install qutip-qtrl from GitHub
-        if: ${{ matrix.qutip-version == '@master'}}
+        if: ${{ matrix.qutip-version == '@master' }}
         run: |
           python -m pip install 'git+https://github.com/qutip/qutip-qtrl.git'
 
@@ -68,7 +82,7 @@ jobs:
           python -m pip install 'jax==0.4.28' 'jaxlib==0.4.28'
 
       - name: Install qutip-jax from GitHub
-        if: ${{ matrix.qutip-version == '@master'}}
+        if: ${{ matrix.qutip-version == '@master' }}
         run: |
           python -m pip install 'git+https://github.com/qutip/qutip-jax.git'
 
@@ -80,28 +94,39 @@ jobs:
       - name: Test with pytest and generate coverage report
         run: |
           pip install pytest-cov coveralls
-          pytest tests --strict-markers --cov=qutip_qoc --cov-report= --color=yes
+          pytest tests \
+            --strict-markers \
+            --cov=qutip_qoc \
+            --cov-report= \
+            --color=yes
 
       - name: Upload to Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_PARALLEL: true
-        run: coveralls --service=github
+        run: |
+          coveralls --service=github
 
   doctest:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-      - name: Install dependencies
+          python-version: "3.11"
+
+      - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip
-          python -mpip install -r doc/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r doc/requirements.txt
           pip install .
+
       - name: Test code snippets in the documentation
         run: |
           cd doc
@@ -111,7 +136,9 @@ jobs:
     name: Finalise coverage reporting
     needs: [cases]
     runs-on: ubuntu-latest
+
     container: python:3-slim
+
     steps:
       - name: Finalise coverage reporting
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,17 +39,14 @@ jobs:
             os: windows-latest
             qutip-version: "@master"
             python-version: "3.12"
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Upgrade pip
-        run: |
-          python -m pip install --upgrade pip
 
       - name: Install QuTiP from GitHub
         if: ${{ matrix.qutip-version == '@master' }}
@@ -71,25 +68,19 @@ jobs:
           python -m pip install 'git+https://github.com/qutip/qutip-jax.git'
 
       - name: Install qutip-qoc
-        # Installing in-place so that coveralls can locate the source code.
         run: |
-          pip install -e .[full]
+          python -m pip install -e .[full]
 
       - name: Test with pytest and generate coverage report
         run: |
-          pip install pytest-cov coveralls
-          pytest tests \
-            --strict-markers \
-            --cov=qutip_qoc \
-            --cov-report= \
-            --color=yes
+          python -m pip install pytest-cov coveralls
+          pytest tests --strict-markers --cov=qutip_qoc --cov-report= --color=yes
 
       - name: Upload to Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_PARALLEL: true
-        run: |
-          coveralls --service=github
+        run: coveralls --service=github
 
   doctest:
     runs-on: ubuntu-latest
@@ -98,18 +89,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Upgrade pip
-        run: |
-          python -m pip install --upgrade pip
-
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
           python -m pip install -r doc/requirements.txt
-          pip install .
+          python -m pip install .
 
       - name: Test code snippets in the documentation
         run: |
@@ -127,6 +115,7 @@ jobs:
       - name: Finalise coverage reporting
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
+
         run: |
           python -m pip install coveralls
           coveralls --service=github --finish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ requires = [
     "cython>=0.29.20",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,3 @@ requires = [
     "cython>=0.29.20",
 ]
 build-backend = "setuptools.build_meta"
-
-[project]
-requires-python = ">=3.11"


### PR DESCRIPTION
**Description**
- Remove Python 3.10 from workflows since `qutip` package requires Python 3.11 as its minimum version (EOL of Python 3.10 is October 2026).
- Upgrade actions to v5/v6 (would solve #72)
- Use `python -m pip install` more consistently 
**AI Tools Usage Disclosure**: GPT-5.5 model for getting suggestions for extra minor refactorings (in addition to the main goal of this PR - to remove Python 3.10, which was straightforward)