### PR TITLE
Add matplotlib dependency for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ rl =
     stable-baselines3>=2.3.2
 tests =
     pytest>=6.0
+    matplotlib
     jupytext
     nbconvert
     ipykernel


### PR DESCRIPTION
Adding `matplotlib` to test dependencies. This resolves the current issue with the "family packages" pipeine in `qutip`, where `qutip-qoc` job started suddenly failing when running interactive tests* ([link](https://github.com/qutip/qutip/actions/runs/27672892649/job/81841163066)), and also makes testing workflows in `qutip-qoc` more robust by being explicit in requiring this dependency for tests. 

*The investigated reason behind its failure: `matplotlib` was a transitive dependency for `qutip-qoc` via `stable-baselines3` `2.8.0`, but it stopped being required in `2.9.0`.